### PR TITLE
Use `exec` in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -146,4 +146,4 @@ then
     update_timezone "$TIMEZONE"
 fi
 
-supervisord -n -c /etc/supervisor/supervisord.conf
+exec supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Without exec supervisord isn't PID 1 and the docker container doesn't respond to any signals
